### PR TITLE
Fixes for upstream

### DIFF
--- a/server/daily.js
+++ b/server/daily.js
@@ -1,49 +1,86 @@
 function checkTags(repo) {
   var new_tags = [];
+  var tag_names = [];
 
-  var headers = { 'User-Agent': Config.user_agent };
-  if (repo.ETag)
-    headers['If-None-Match'] = repo.ETag;
-  try {
-    var result = Meteor.http.get(repo.tags_url, {
-      params: {
-        client_id: Config.gh_client_id,
-        client_secret: Config.gh_client_secret
-      },
-      headers: headers
-    });
+  var page = 1;
 
-    if (result.statusCode === 304) {
-      // console.log('# ' + repo.full_name + ' - 304 Not Modified');
-      return []; // The file hasn't changed since last time we looked at it
-    } else if (result.statusCode === 403) {
-      console.warn('-> Rate limited during ' + repo.full_name + ' check until ' + result.headers.x-ratelimit-reset);
+  var etags = [];
+
+  var existing_tags = repo.tags;
+  if (existing_tags === undefined)
+    existing_tags = [];
+  console.log('# ' + repo.full_name + ' - Existing tags: ' + existing_tags);
+
+  while (true) {
+    try {
+      var headers = { 'User-Agent': Config.user_agent };
+      if (repo.ETag !== undefined && page-1 in repo.ETag)
+        headers['If-None-Match'] = repo.ETag[page-1];
+      var result = Meteor.http.get(repo.tags_url, {
+        params: {
+          client_id: Config.gh_client_id,
+          client_secret: Config.gh_client_secret,
+          page: page
+        },
+        headers: headers
+      });
+    } catch (err) {
+      console.warn('-> Error getting tags for ' + repo.full_name + '.');
+      console.warn(err);
       return [];
     }
 
-    var tag_names = result.data.map(function(tag) {
-      return tag.name;
-    });
-
-    if (!repo.fresh) {
-      new_tags = tag_names.filter(function(tag) {
-        return repo.tags.indexOf(tag) === -1
+    if (result.statusCode === 304) {
+      console.log('# ' + repo.full_name + ' - 304 Not Modified');
+    } else if (result.statusCode === 403) {
+      console.warn('-> Rate limited during ' + repo.full_name + ' check until ' + result.headers.x-ratelimit-reset);
+      break;
+    } else {
+      var addl_tag_names = result.data.map(function(tag) {
+        return tag.name;
       });
+
+      console.log('# ' + repo.full_name + ' - Page ' + page + ' tags: ' + addl_tag_names);
+
+      tag_names = tag_names.concat(addl_tag_names);
     }
 
-    console.log('# ' + repo.full_name + ' - Found ' + new_tags.length + ' New Tags');
+    etags[page-1] = result.headers.etag;
 
-    Repos.update({ _id: repo._id }, {
-      $set: {
-        fresh: false,
-        tags: tag_names,
-        ETag: result.headers.etag
+    if ('link' in result.headers) {
+      next = parseLinkHeader(result.headers.link).next;
+      if (next === undefined) {
+        break;
       }
-    });
-  } catch (err) {
-    console.warn('-> Error getting tags for ' + repo.full_name + '.');
-    console.warn(err);
+      page = next.page;
+    } else if (repo.ETag !== undefined && page < repo.ETag.length) {
+      page++;
+    } else {
+      break;
+    }
   }
+
+  console.log('# ' + repo.full_name + ' - All tags: ' + tag_names);
+
+  if (!repo.fresh) {
+    new_tags = tag_names.filter(function(tag) {
+      return existing_tags.indexOf(tag) === -1
+    });
+  } else {
+    existing_tags = tag_names;
+  }
+
+  console.log('# ' + repo.full_name + ' - Found ' + new_tags.length + ' New Tags');
+  console.log('# ' + repo.full_name + ' - New tags: ' + new_tags);
+
+  Repos.update({ _id: repo._id }, {
+    $set: {
+      fresh: false,
+      tags: existing_tags.concat(new_tags),
+      ETag: etags
+    }
+  });
+
   return new_tags;
 }
 

--- a/server/daily.js
+++ b/server/daily.js
@@ -84,12 +84,27 @@ function checkTags(repo) {
   return new_tags;
 }
 
+function checkSchema(repo) {
+  if (!(repo.ETag instanceof Array)) {
+    console.log('** Updating schema and restarting ' + repo.full_name);
+    repo.ETag = undefined;
+    Repos.update({ _id: repo._id }, {
+      $set: {
+        fresh: true,
+        ETag: undefined
+      }
+    });
+  }
+}
+
 function checkAllTags() {
   console.log('!! Checking Tags');
   var repos = Repos.find();
   var newTags = {};
 
   repos.forEach(function(repo) {
+    checkSchema(repo);
+
     newTags[repo.full_name] = _.extend(repo, {
       newTags: checkTags(repo)
     });

--- a/server/daily.js
+++ b/server/daily.js
@@ -16,6 +16,9 @@ function checkTags(repo) {
     if (result.statusCode === 304) {
       // console.log('# ' + repo.full_name + ' - 304 Not Modified');
       return []; // The file hasn't changed since last time we looked at it
+    } else if (result.statusCode === 403) {
+      console.warn('-> Rate limited during ' + repo.full_name + ' check until ' + result.headers.x-ratelimit-reset);
+      return [];
     }
 
     var tag_names = result.data.map(function(tag) {


### PR DESCRIPTION
This fixes #1. It will reset the single ETag so all pages will be rechecked - necessary since it can only detect a new page when an ETag changes. It will also mark each existing repo as fresh again so users are not bombarded with tags from pages that were never checked before.

Depending on the number of repos the first check after updating may hit the rate limit. If this happens it (should) abort the check cleanly and recheck again the next hour. Could take some time to sync up...